### PR TITLE
fix: add file package to duo dependencies

### DIFF
--- a/modules/webapps/copyparty/bart.nix
+++ b/modules/webapps/copyparty/bart.nix
@@ -20,6 +20,7 @@ in
           runtimeInputs = with pkgs; [
             coreutils
             curl
+            file
             gawk
             gnugrep
             libnotify


### PR DESCRIPTION
This PR adds the `file` dependency to `duo`. Otherwise, this won't work when `file` is not in system/home packages or `PATH` in general.
